### PR TITLE
Hotfix/bump version websocket dep

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Slack.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 1.2"},
-      {:websocket_client, "~> 1.2"},
+      {:websocket_client, "~> 1.5"},
       {:jason, "~> 1.1"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:credo, "~> 1.6", only: [:dev, :test]},

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Slack.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/BlakeWilliams/Elixir-Slack"
-  @version "0.23.6"
+  @version "0.23.7"
 
   def project do
     [

--- a/mix.lock
+++ b/mix.lock
@@ -27,5 +27,5 @@
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
-  "websocket_client": {:hex, :websocket_client, "1.4.2", "f1036e3f9427eecdb66808eee56dbcaeb5a1a352306e6a0d0d23a9487205f4d7", [:rebar3], [], "hexpm", "c005e5f8f2f6a8533c497a509dc52f3e6fb42fa2e0d67bff8ebc8802868d84ed"},
+  "websocket_client": {:hex, :websocket_client, "1.5.0", "e825f23c51a867681a222148ed5200cc4a12e4fb5ff0b0b35963e916e2b5766b", [:rebar3], [], "hexpm", "2b9b201cc5c82b9d4e6966ad8e605832eab8f4ddb39f57ac62f34cb208b68de9"},
 }


### PR DESCRIPTION
Bumped `websocket_client` version to make library compatible with OTP25. Currently `websocket_client` with version `1.2` leads to a `UndefinedFunctionError` due to deprecation in OTP 21 and subsequent removal in OTP 25 of `:http_uri.parse/2`.